### PR TITLE
⚙️ Deploy SDK Generator Action - Add updated actions and docs

### DIFF
--- a/DEPLOYMENT_INFO
+++ b/DEPLOYMENT_INFO
@@ -1,0 +1,4 @@
+Deployed from: aporthq/agent-passport@90dcea124e3bb050fe026e8861c134644a2f5675
+Deployed at: Mon Sep 22 19:41:12 UTC 2025
+Triggered by: uchibeke
+Action: sdk-generator

--- a/README.md
+++ b/README.md
@@ -1,1 +1,338 @@
-# sdk-generator-action
+# APort SDK Generator Action
+
+Generate SDKs and client libraries for APort agents in multiple programming languages.
+
+## 🚀 Features
+
+- **Multi-language Support** - Generate SDKs for Python, Node.js, Go, and more
+- **Type Safety** - Include TypeScript definitions and type hints
+- **Agent-specific** - Generate SDKs tailored to specific agent capabilities
+- **GitHub Integration** - Seamless integration with GitHub Actions
+- **Flexible Output** - Configurable output directories and formats
+
+## 📋 Usage
+
+### Basic Usage
+
+```yaml
+name: Generate APort SDK
+on:
+  push:
+    branches: [main]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs'
+          output-dir: './generated-sdk'
+```
+
+### Advanced Usage
+
+```yaml
+name: Advanced SDK Generation
+on:
+  workflow_dispatch:
+    inputs:
+      agent_id:
+        description: 'Agent ID to generate SDK for'
+        required: true
+      languages:
+        description: 'Languages to generate'
+        required: false
+        default: 'python,nodejs,go'
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ github.event.inputs.agent_id }}
+          languages: ${{ github.event.inputs.languages }}
+          output-dir: './generated-sdk'
+          include-types: 'true'
+          api-base: 'https://api.aport.io'
+```
+
+## 🔧 Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `agent-id` | The APort Agent ID to generate SDK for | ✅ | - |
+| `api-base` | The base URL for the APort API | ❌ | `https://api.aport.io` |
+| `output-dir` | Directory to output generated SDK files | ❌ | `./generated-sdk` |
+| `languages` | Comma-separated list of languages to generate | ❌ | `python,nodejs` |
+| `include-types` | Whether to include TypeScript type definitions | ❌ | `true` |
+| `github-token` | GitHub token for publishing generated SDKs | ❌ | `${{ github.token }}` |
+
+## 📤 Outputs
+
+| Output | Description |
+|--------|-------------|
+| `generated_files` | JSON array of generated file paths |
+| `languages_generated` | JSON array of languages that were successfully generated |
+| `success` | Boolean indicating if SDK generation was successful |
+
+## 🏗️ Setup
+
+### 1. Create APort Agent
+
+1. Go to [APort Dashboard](https://aport.io)
+2. Create a new agent
+3. Configure capabilities and policies
+4. Note the Agent ID
+
+### 2. Set GitHub Secrets
+
+Add the following secrets to your repository:
+
+```bash
+APORT_AGENT_ID=your-agent-id-here
+```
+
+## 🌐 Supported Languages
+
+### Python
+
+Generates a complete Python package with:
+
+- **Client Class** - `APortClient` for API interactions
+- **Type Definitions** - Pydantic models for type safety
+- **Requirements** - Dependencies in `requirements.txt`
+- **Package Structure** - Proper Python package layout
+
+```python
+from aport_sdk import APortClient, PolicyContext
+
+client = APortClient(api_base="https://api.aport.io")
+passport = client.get_passport()
+result = client.verify_policy(PolicyContext(
+    repo="owner/repo",
+    base_branch="main",
+    github_actor="user"
+))
+```
+
+### Node.js
+
+Generates a complete Node.js package with:
+
+- **TypeScript Support** - Full type definitions
+- **Modern JavaScript** - ES2020+ features
+- **Package.json** - Proper npm package configuration
+- **Build System** - TypeScript compilation setup
+
+```typescript
+import { APortClient, PolicyContext } from '@aport/sdk-agent-id';
+
+const client = new APortClient('https://api.aport.io');
+const passport = await client.getPassport();
+const result = await client.verifyPolicy({
+  repo: 'owner/repo',
+  base_branch: 'main',
+  github_actor: 'user'
+});
+```
+
+### Go
+
+Generates a complete Go module with:
+
+- **Client Struct** - `APortClient` for API interactions
+- **Type Definitions** - Structs for all data types
+- **Go Modules** - Proper `go.mod` configuration
+- **Error Handling** - Comprehensive error handling
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/aport/sdk-agent-id"
+)
+
+func main() {
+    client := aport.NewClient("https://api.aport.io")
+    passport, err := client.GetPassport()
+    if err != nil {
+        panic(err)
+    }
+    
+    ctx := aport.PolicyContext{
+        Repo: "owner/repo",
+        BaseBranch: "main",
+        GitHubActor: &[]string{"user"}[0],
+    }
+    
+    result, err := client.VerifyPolicy(ctx)
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
+## 📚 Examples
+
+### Generate and Publish SDK
+
+```yaml
+name: Generate and Publish SDK
+on:
+  push:
+    branches: [main]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        id: generate
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs,go'
+          output-dir: './generated-sdk'
+      
+      - name: Publish Python SDK
+        if: contains(steps.generate.outputs.languages_generated, 'python')
+        run: |
+          cd generated-sdk/python
+          pip install build
+          python -m build
+          # Add your publishing logic here
+      
+      - name: Publish Node.js SDK
+        if: contains(steps.generate.outputs.languages_generated, 'nodejs')
+        run: |
+          cd generated-sdk/nodejs
+          npm publish
+          # Add your publishing logic here
+```
+
+### Multi-language SDK Generation
+
+```yaml
+name: Multi-language SDK
+on:
+  workflow_dispatch:
+    inputs:
+      languages:
+        description: 'Languages to generate'
+        required: true
+        default: 'python,nodejs,go,rust'
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: ${{ github.event.inputs.languages }}
+          output-dir: './generated-sdk'
+          include-types: 'true'
+      
+      - name: Upload SDK Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: generated-sdk
+          path: generated-sdk/
+```
+
+### Conditional SDK Generation
+
+```yaml
+name: Conditional SDK Generation
+on:
+  push:
+    branches: [main, staging]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate Production SDK
+        if: github.ref == 'refs/heads/main'
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs,go'
+          output-dir: './production-sdk'
+      
+      - name: Generate Development SDK
+        if: github.ref == 'refs/heads/staging'
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs'
+          output-dir: './development-sdk'
+```
+
+## 🚨 Troubleshooting
+
+### Common Issues
+
+1. **Agent not found**
+   - Verify `APORT_AGENT_ID` is correct
+   - Check agent exists in APort dashboard
+
+2. **Language not supported**
+   - Check supported languages list
+   - Verify language name spelling
+
+3. **Generation failed**
+   - Check agent capabilities
+   - Verify API connectivity
+
+### Debug Mode
+
+Enable debug logging:
+
+```yaml
+- name: Generate SDK
+  uses: aporthq/sdk-generator-action@v1
+  with:
+    agent-id: ${{ secrets.APORT_AGENT_ID }}
+    languages: 'python,nodejs'
+    debug: true
+```
+
+## 📚 Examples
+
+See the `example-repo/` directory for complete working examples.
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Submit a pull request
+
+## 📄 License
+
+MIT License - see LICENSE file for details.
+
+## 🆘 Support
+
+- 📖 [Documentation](https://aport.io/docs)
+- 💬 [Discord Community](https://discord.gg/aport)
+- 🐛 [Issue Tracker](https://github.com/aporthq/sdk-generator-action/issues)
+- 📧 [Email Support](mailto:support@aport.io)

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,440 @@
+name: "APort SDK Generator"
+description: "Generate SDKs and client libraries for APort agents"
+author: "APort Team"
+branding:
+  icon: "code"
+  color: "purple"
+
+inputs:
+  agent-id:
+    description: "The APort Agent ID to generate SDK for."
+    required: true
+  api-base:
+    description: "The base URL for the APort API."
+    required: false
+    default: "https://api.aport.io"
+  output-dir:
+    description: "Directory to output generated SDK files."
+    required: false
+    default: "./generated-sdk"
+  languages:
+    description: "Comma-separated list of languages to generate (e.g., 'python,nodejs,go')."
+    required: false
+    default: "python,nodejs"
+  include-types:
+    description: "Whether to include TypeScript type definitions."
+    required: false
+    default: "true"
+  github-token:
+    description: "GitHub token for publishing generated SDKs."
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  generated_files:
+    description: "JSON array of generated file paths."
+    value: ${{ steps.sdk-generator.outputs.generated_files }}
+  languages_generated:
+    description: "JSON array of languages that were successfully generated."
+    value: ${{ steps.sdk-generator.outputs.languages_generated }}
+  success:
+    description: "Boolean indicating if SDK generation was successful."
+    value: ${{ steps.sdk-generator.outputs.success }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate SDK
+      id: sdk-generator
+      env:
+        APORT_API_BASE: ${{ inputs.api-base }}
+        APORT_AGENT_ID: ${{ inputs.agent-id }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+        LANGUAGES: ${{ inputs.languages }}
+        INCLUDE_TYPES: ${{ inputs.include-types }}
+      run: |
+        echo "🔧 Generating SDK for agent: $APORT_AGENT_ID"
+        echo "Languages: $LANGUAGES"
+        echo "Output directory: $OUTPUT_DIR"
+        
+        # Create output directory
+        mkdir -p "$OUTPUT_DIR"
+        
+        # Get agent passport to understand capabilities
+        echo "📥 Fetching agent passport..."
+        RESPONSE=$(curl -s -X GET "$APORT_API_BASE/api/verify/$APORT_AGENT_ID")
+        
+        if [ $? -ne 0 ]; then
+          echo "❌ Failed to fetch agent passport"
+          echo "success=false" >> $GITHUB_OUTPUT
+          exit 1
+        fi
+        
+        # Parse agent capabilities
+        CAPABILITIES=$(echo "$RESPONSE" | jq -r '.capabilities // []')
+        ASSURANCE_LEVEL=$(echo "$RESPONSE" | jq -r '.assurance_level // 0')
+        AGENT_NAME=$(echo "$RESPONSE" | jq -r '.name // "Unknown Agent"')
+        
+        echo "📊 Agent: $AGENT_NAME (Assurance Level: $ASSURANCE_LEVEL)"
+        echo "🔧 Capabilities: $CAPABILITIES"
+        
+        # Generate SDK for each language
+        IFS=',' read -ra LANG_ARRAY <<< "$LANGUAGES"
+        GENERATED_FILES="[]"
+        GENERATED_LANGS="[]"
+        
+        for lang in "${LANG_ARRAY[@]}"; do
+          lang=$(echo "$lang" | xargs) # trim whitespace
+          echo "🚀 Generating $lang SDK..."
+          
+          case "$lang" in
+            "python")
+              mkdir -p "$OUTPUT_DIR/python"
+              # Generate Python SDK
+              cat > "$OUTPUT_DIR/python/__init__.py" << EOF
+"""
+APort SDK for $AGENT_NAME
+Generated automatically by APort SDK Generator
+"""
+
+__version__ = "1.0.0"
+__agent_id__ = "$APORT_AGENT_ID"
+__assurance_level__ = $ASSURANCE_LEVEL
+
+from .client import APortClient
+from .types import AgentPassport, PolicyContext
+
+__all__ = ["APortClient", "AgentPassport", "PolicyContext"]
+EOF
+              
+              cat > "$OUTPUT_DIR/python/client.py" << EOF
+"""APort Client for $AGENT_NAME"""
+
+import requests
+from typing import Dict, Any, Optional
+from .types import AgentPassport, PolicyContext
+
+class APortClient:
+    def __init__(self, api_base: str = "$APORT_API_BASE"):
+        self.api_base = api_base.rstrip('/')
+        self.agent_id = "$APORT_AGENT_ID"
+    
+    def get_passport(self) -> AgentPassport:
+        """Get the agent passport"""
+        response = requests.get(f"{self.api_base}/api/verify/{self.agent_id}")
+        response.raise_for_status()
+        return AgentPassport(**response.json())
+    
+    def verify_policy(self, context: PolicyContext) -> Dict[str, Any]:
+        """Verify policy against agent"""
+        response = requests.post(
+            f"{self.api_base}/api/verify/policy/repo.v1",
+            json={"agent_id": self.agent_id, "context": context.dict()}
+        )
+        response.raise_for_status()
+        return response.json()
+EOF
+              
+              cat > "$OUTPUT_DIR/python/types.py" << EOF
+"""Type definitions for APort SDK"""
+
+from typing import Dict, Any, Optional, List
+from dataclasses import dataclass
+
+@dataclass
+class PolicyContext:
+    repo: str
+    base_branch: str
+    github_actor: Optional[str] = None
+    github_app: Optional[str] = None
+    files_changed: int = 0
+    lines_added: int = 0
+    labels: List[str] = None
+    reviews: int = 0
+    is_draft: bool = False
+    is_mergeable: bool = True
+
+@dataclass
+class AgentPassport:
+    agent_id: str
+    name: str
+    assurance_level: int
+    assurance_method: str
+    capabilities: List[str]
+    # Add other fields as needed
+EOF
+              
+              cat > "$OUTPUT_DIR/python/requirements.txt" << EOF
+requests>=2.28.0
+pydantic>=1.10.0
+EOF
+              
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/python/__init__.py" '. + [$file]')
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/python/client.py" '. + [$file]')
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/python/types.py" '. + [$file]')
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/python/requirements.txt" '. + [$file]')
+              GENERATED_LANGS=$(echo "$GENERATED_LANGS" | jq --arg lang "python" '. + [$lang]')
+              ;;
+              
+            "nodejs")
+              mkdir -p "$OUTPUT_DIR/nodejs"
+              # Generate Node.js SDK
+              cat > "$OUTPUT_DIR/nodejs/package.json" << EOF
+{
+  "name": "@aport/sdk-$APORT_AGENT_ID",
+  "version": "1.0.0",
+  "description": "APort SDK for $AGENT_NAME",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "axios": "^1.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "typescript": "^4.9.0",
+    "jest": "^29.0.0"
+  }
+}
+EOF
+              
+              cat > "$OUTPUT_DIR/nodejs/src/index.ts" << EOF
+/**
+ * APort SDK for $AGENT_NAME
+ * Generated automatically by APort SDK Generator
+ */
+
+export interface PolicyContext {
+  repo: string;
+  base_branch: string;
+  github_actor?: string;
+  github_app?: string;
+  files_changed: number;
+  lines_added: number;
+  labels: string[];
+  reviews: number;
+  is_draft: boolean;
+  is_mergeable: boolean;
+}
+
+export interface AgentPassport {
+  agent_id: string;
+  name: string;
+  assurance_level: number;
+  assurance_method: string;
+  capabilities: string[];
+}
+
+export class APortClient {
+  private apiBase: string;
+  private agentId: string;
+
+  constructor(apiBase: string = "$APORT_API_BASE") {
+    this.apiBase = apiBase.replace(/\/$/, '');
+    this.agentId = "$APORT_AGENT_ID";
+  }
+
+  async getPassport(): Promise<AgentPassport> {
+    const response = await fetch(\`\${this.apiBase}/api/verify/\${this.agentId}\`);
+    if (!response.ok) {
+      throw new Error(\`Failed to fetch passport: \${response.statusText}\`);
+    }
+    return response.json();
+  }
+
+  async verifyPolicy(context: PolicyContext): Promise<any> {
+    const response = await fetch(\`\${this.apiBase}/api/verify/policy/repo.v1\`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        agent_id: this.agentId,
+        context
+      })
+    });
+    
+    if (!response.ok) {
+      throw new Error(\`Policy verification failed: \${response.statusText}\`);
+    }
+    
+    return response.json();
+  }
+}
+EOF
+              
+              cat > "$OUTPUT_DIR/nodejs/tsconfig.json" << EOF
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+EOF
+              
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/nodejs/package.json" '. + [$file]')
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/nodejs/src/index.ts" '. + [$file]')
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/nodejs/tsconfig.json" '. + [$file]')
+              GENERATED_LANGS=$(echo "$GENERATED_LANGS" | jq --arg lang "nodejs" '. + [$lang]')
+              ;;
+              
+            "go")
+              mkdir -p "$OUTPUT_DIR/go"
+              # Generate Go SDK
+              cat > "$OUTPUT_DIR/go/go.mod" << EOF
+module github.com/aport/sdk-$APORT_AGENT_ID
+
+go 1.19
+
+require (
+    github.com/stretchr/testify v1.8.2
+)
+EOF
+              
+              cat > "$OUTPUT_DIR/go/client.go" << EOF
+package aport
+
+import (
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+)
+
+// PolicyContext represents the context for policy verification
+type PolicyContext struct {
+    Repo         string   \`json:"repo"\`
+    BaseBranch   string   \`json:"base_branch"\`
+    GitHubActor  *string  \`json:"github_actor,omitempty"\`
+    GitHubApp    *string  \`json:"github_app,omitempty"\`
+    FilesChanged int      \`json:"files_changed"\`
+    LinesAdded   int      \`json:"lines_added"\`
+    Labels       []string \`json:"labels"\`
+    Reviews      int      \`json:"reviews"\`
+    IsDraft      bool     \`json:"is_draft"\`
+    IsMergeable  bool     \`json:"is_mergeable"\`
+}
+
+// AgentPassport represents the agent passport
+type AgentPassport struct {
+    AgentID         string   \`json:"agent_id"\`
+    Name            string   \`json:"name"\`
+    AssuranceLevel  int      \`json:"assurance_level"\`
+    AssuranceMethod string   \`json:"assurance_method"\`
+    Capabilities    []string \`json:"capabilities"\`
+}
+
+// APortClient is the main client for interacting with APort
+type APortClient struct {
+    apiBase  string
+    agentID  string
+    client   *http.Client
+}
+
+// NewClient creates a new APort client
+func NewClient(apiBase string) *APortClient {
+    if apiBase == "" {
+        apiBase = "$APORT_API_BASE"
+    }
+    return &APortClient{
+        apiBase: apiBase,
+        agentID: "$APORT_AGENT_ID",
+        client:  &http.Client{},
+    }
+}
+
+// GetPassport retrieves the agent passport
+func (c *APortClient) GetPassport() (*AgentPassport, error) {
+    url := fmt.Sprintf("%s/api/verify/%s", c.apiBase, c.agentID)
+    resp, err := c.client.Get(url)
+    if err != nil {
+        return nil, err
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        return nil, fmt.Errorf("failed to fetch passport: %s", resp.Status)
+    }
+
+    var passport AgentPassport
+    if err := json.NewDecoder(resp.Body).Decode(&passport); err != nil
+        return nil, err
+    }
+
+    return &passport, nil
+}
+
+// VerifyPolicy verifies policy against the agent
+func (c *APortClient) VerifyPolicy(ctx PolicyContext) (map[string]interface{}, error) {
+    url := fmt.Sprintf("%s/api/verify/policy/repo.v1", c.apiBase)
+    
+    payload := map[string]interface{}{
+        "agent_id": c.agentID,
+        "context":  ctx,
+    }
+
+    jsonData, err := json.Marshal(payload)
+    if err != nil {
+        return nil, err
+    }
+
+    resp, err := c.client.Post(url, "application/json", bytes.NewBuffer(jsonData))
+    if err != nil {
+        return nil, err
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        return nil, fmt.Errorf("policy verification failed: %s", resp.Status)
+    }
+
+    var result map[string]interface{}
+    if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+        return nil, err
+    }
+
+    return result, nil
+}
+EOF
+              
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/go/go.mod" '. + [$file]')
+              GENERATED_FILES=$(echo "$GENERATED_FILES" | jq --arg file "$OUTPUT_DIR/go/client.go" '. + [$file]')
+              GENERATED_LANGS=$(echo "$GENERATED_LANGS" | jq --arg lang "go" '. + [$lang]')
+              ;;
+              
+            *)
+              echo "⚠️ Unsupported language: $lang"
+              ;;
+          esac
+        done
+        
+        echo "generated_files=$GENERATED_FILES" >> $GITHUB_OUTPUT
+        echo "languages_generated=$GENERATED_LANGS" >> $GITHUB_OUTPUT
+        echo "success=true" >> $GITHUB_OUTPUT
+        
+        echo "✅ SDK generation completed successfully"
+      shell: bash
+
+    - name: Report results
+      run: |
+        echo "📊 SDK Generation Results:"
+        echo "  Agent ID: ${{ inputs.agent-id }}"
+        echo "  Languages: ${{ steps.sdk-generator.outputs.languages_generated }}"
+        echo "  Files Generated: ${{ steps.sdk-generator.outputs.generated_files }}"
+        echo "  Success: ${{ steps.sdk-generator.outputs.success }}"

--- a/example-repo/.github/workflows/sdk-generation.yml
+++ b/example-repo/.github/workflows/sdk-generation.yml
@@ -1,0 +1,74 @@
+# APort SDK Generation Workflow
+# This workflow generates SDKs and client libraries for APort agents
+name: APort SDK Generation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      agent_id:
+        description: "Agent ID to generate SDK for"
+        required: true
+        type: string
+      languages:
+        description: "Languages to generate"
+        required: false
+        default: "python,nodejs,go"
+        type: string
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    name: Generate SDK
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate SDK
+        id: generate
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ github.event.inputs.agent_id || secrets.APORT_AGENT_ID }}
+          languages: ${{ github.event.inputs.languages || 'python,nodejs,go' }}
+          output-dir: "./generated-sdk"
+          include-types: "true"
+
+      - name: Upload SDK Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: generated-sdk
+          path: generated-sdk/
+
+      - name: Publish Python SDK
+        if: contains(steps.generate.outputs.languages_generated, 'python')
+        run: |
+          echo "📦 Publishing Python SDK..."
+          cd generated-sdk/python
+          # Add your Python publishing logic here
+          echo "✅ Python SDK published"
+
+      - name: Publish Node.js SDK
+        if: contains(steps.generate.outputs.languages_generated, 'nodejs')
+        run: |
+          echo "📦 Publishing Node.js SDK..."
+          cd generated-sdk/nodejs
+          # Add your Node.js publishing logic here
+          echo "✅ Node.js SDK published"
+
+      - name: Publish Go SDK
+        if: contains(steps.generate.outputs.languages_generated, 'go')
+        run: |
+          echo "📦 Publishing Go SDK..."
+          cd generated-sdk/go
+          # Add your Go publishing logic here
+          echo "✅ Go SDK published"
+
+      - name: Report Results
+        run: |
+          echo "📊 SDK Generation Results:"
+          echo "  Agent ID: ${{ github.event.inputs.agent_id || secrets.APORT_AGENT_ID }}"
+          echo "  Languages: ${{ steps.generate.outputs.languages_generated }}"
+          echo "  Files Generated: ${{ steps.generate.outputs.generated_files }}"
+          echo "  Success: ${{ steps.generate.outputs.success }}"

--- a/example-repo/README.md
+++ b/example-repo/README.md
@@ -1,0 +1,305 @@
+# APort SDK Generator Example
+
+This repository demonstrates how to use the APort SDK Generator GitHub Action to generate SDKs and client libraries for APort agents in multiple programming languages.
+
+## 🚀 Quick Start
+
+### 1. Fork this Repository
+
+Click the "Fork" button to create your own copy of this repository.
+
+### 2. Set up APort Agent
+
+1. Go to [APort Dashboard](https://aport.io)
+2. Create a new agent
+3. Configure the agent with capabilities and policies
+4. Note the Agent ID
+
+### 3. Configure GitHub Secrets
+
+Add the following secrets to your repository:
+
+1. Go to **Settings** → **Secrets and variables** → **Actions**
+2. Click **New repository secret**
+3. Add the following secrets:
+
+| Secret Name | Description | Example Value |
+|-------------|-------------|---------------|
+| `APORT_AGENT_ID` | Your APort Agent ID | `agent_1234567890abcdef` |
+
+### 4. Test the Action
+
+1. Push changes to the main branch
+2. The action will automatically generate SDKs
+3. Or trigger manually via **Actions** → **APort SDK Generation** → **Run workflow**
+
+## 🔧 Configuration
+
+### Supported Languages
+
+| Language | Description | Output |
+|----------|-------------|--------|
+| `python` | Python SDK with type hints | Complete Python package |
+| `nodejs` | Node.js SDK with TypeScript | npm package with types |
+| `go` | Go SDK with structs | Go module |
+
+### Workflow Configuration
+
+The workflow is configured to run on:
+
+- **Push Events:** When changes are pushed to main branch
+- **Manual Dispatch:** Can be triggered manually with custom parameters
+
+## 📊 Usage Examples
+
+### Basic SDK Generation
+
+```yaml
+name: Basic SDK Generation
+on:
+  push:
+    branches: [main]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs'
+          output-dir: './generated-sdk'
+```
+
+### Multi-language SDK Generation
+
+```yaml
+name: Multi-language SDK
+on:
+  workflow_dispatch:
+    inputs:
+      languages:
+        description: "Languages to generate"
+        required: true
+        default: "python,nodejs,go,rust"
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: ${{ github.event.inputs.languages }}
+          output-dir: './generated-sdk'
+          include-types: 'true'
+```
+
+### Conditional SDK Generation
+
+```yaml
+name: Conditional SDK Generation
+on:
+  push:
+    branches: [main, staging]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate Production SDK
+        if: github.ref == 'refs/heads/main'
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs,go'
+          output-dir: './production-sdk'
+      
+      - name: Generate Development SDK
+        if: github.ref == 'refs/heads/staging'
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs'
+          output-dir: './development-sdk'
+```
+
+## 🚨 Troubleshooting
+
+### Common Issues
+
+1. **"Agent not found" error**
+   - Verify `APORT_AGENT_ID` secret is correct
+   - Check agent exists in APort dashboard
+
+2. **"Language not supported" error**
+   - Check supported languages list
+   - Verify language name spelling
+
+3. **"Generation failed" error**
+   - Check agent capabilities
+   - Verify API connectivity
+
+### Debug Mode
+
+To enable debug logging, modify the workflow:
+
+```yaml
+- name: Generate SDK
+  uses: aporthq/sdk-generator-action@v1
+  with:
+    agent-id: ${{ secrets.APORT_AGENT_ID }}
+    languages: 'python,nodejs'
+    debug: true  # Add this line
+```
+
+## 📚 Advanced Examples
+
+### Generate and Publish SDK
+
+```yaml
+name: Generate and Publish SDK
+on:
+  push:
+    branches: [main]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        id: generate
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs,go'
+          output-dir: './generated-sdk'
+      
+      - name: Publish Python SDK
+        if: contains(steps.generate.outputs.languages_generated, 'python')
+        run: |
+          cd generated-sdk/python
+          pip install build
+          python -m build
+          # Add your publishing logic here
+      
+      - name: Publish Node.js SDK
+        if: contains(steps.generate.outputs.languages_generated, 'nodejs')
+        run: |
+          cd generated-sdk/nodejs
+          npm publish
+          # Add your publishing logic here
+```
+
+### SDK Versioning
+
+```yaml
+name: SDK Versioning
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs,go'
+          output-dir: './generated-sdk'
+      
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: SDK Release ${{ github.ref }}
+          body: |
+            Generated SDKs for agent ${{ secrets.APORT_AGENT_ID }}
+            
+            Languages: ${{ steps.generate.outputs.languages_generated }}
+          files: generated-sdk/*
+```
+
+### SDK Testing
+
+```yaml
+name: SDK Testing
+on:
+  push:
+    branches: [main]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Generate SDK
+        uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: 'python,nodejs,go'
+          output-dir: './generated-sdk'
+      
+      - name: Test Python SDK
+        if: contains(steps.generate.outputs.languages_generated, 'python')
+        run: |
+          cd generated-sdk/python
+          pip install -e .
+          python -c "import aport_sdk; print('Python SDK imported successfully')"
+      
+      - name: Test Node.js SDK
+        if: contains(steps.generate.outputs.languages_generated, 'nodejs')
+        run: |
+          cd generated-sdk/nodejs
+          npm install
+          npm run build
+          node -e "console.log('Node.js SDK built successfully')"
+      
+      - name: Test Go SDK
+        if: contains(steps.generate.outputs.languages_generated, 'go')
+        run: |
+          cd generated-sdk/go
+          go mod tidy
+          go build
+          echo "Go SDK built successfully"
+```
+
+## 🤝 Contributing
+
+1. Fork this repository
+2. Create a feature branch
+3. Make your changes
+4. Submit a pull request
+
+## 📄 License
+
+MIT License - see LICENSE file for details.
+
+## 🆘 Support
+
+- 📖 [APort Documentation](https://aport.io/docs)
+- 💬 [Discord Community](https://discord.gg/aport)
+- 🐛 [Issue Tracker](https://github.com/aporthq/sdk-generator-action/issues)
+- 📧 [Email Support](mailto:support@aport.io)
+
+## 🔗 Related
+
+- [APort Dashboard](https://aport.io)
+- [SDK Generator Action](https://github.com/aporthq/sdk-generator-action)
+- [APort Documentation](https://aport.io/docs)

--- a/simple-example.yml
+++ b/simple-example.yml
@@ -1,0 +1,16 @@
+# Simple APort SDK Generation
+# Copy this to your .github/workflows/ directory
+
+name: Generate APort SDK
+on: [workflow_dispatch]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: "python,nodejs"
+          output-dir: "./generated-sdk"


### PR DESCRIPTION
## ⚙️ SDK Generator Action Changes

**Source Commit:** `90dcea124e3bb050fe026e8861c134644a2f5675`
**Commit Message:** `Add updated actions and docs`
**Changed Files:**

- `integrations/github/actions/sdk-generator/README.md`
- `integrations/github/actions/sdk-generator/action.yml`
- `integrations/github/actions/sdk-generator/example-repo/README.md`
- `integrations/github/actions/sdk-generator/simple-example.yml`

### File Changes:

```diff
diff --git a/integrations/github/actions/sdk-generator/README.md b/integrations/github/actions/sdk-generator/README.md
index ab1c698..831eac8 100644
--- a/integrations/github/actions/sdk-generator/README.md
+++ b/integrations/github/actions/sdk-generator/README.md
@@ -62,7 +62,7 @@ jobs:
           languages: ${{ github.event.inputs.languages }}
           output-dir: './generated-sdk'
           include-types: 'true'
-          api-base: 'https://api.aport.dev'
+          api-base: 'https://api.aport.io'
 ```
 
 ## 🔧 Inputs
@@ -70,7 +70,7 @@ jobs:
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `agent-id` | The APort Agent ID to generate SDK for | ✅ | - |
-| `api-base` | The base URL for the APort API | ❌ | `https://api.aport.dev` |
+| `api-base` | The base URL for the APort API | ❌ | `https://api.aport.io` |
 | `output-dir` | Directory to output generated SDK files | ❌ | `./generated-sdk` |
 | `languages` | Comma-separated list of languages to generate | ❌ | `python,nodejs` |
 | `include-types` | Whether to include TypeScript type definitions | ❌ | `true` |
@@ -88,7 +88,7 @@ jobs:
 
 ### 1. Create APort Agent
 
-1. Go to [APort Dashboard](https://aport.dev)
+1. Go to [APort Dashboard](https://aport.io)
 2. Create a new agent
 3. Configure capabilities and policies
 4. Note the Agent ID
@@ -115,7 +115,7 @@ Generates a complete Python package with:
 ```python
 from aport_sdk import APortClient, PolicyContext
 
-client = APortClient(api_base="https://api.aport.dev")
+client = APortClient(api_base="https://api.aport.io")
 passport = client.get_passport()
 result = client.verify_policy(PolicyContext(
     repo="owner/repo",
@@ -136,7 +136,7 @@ Generates a complete Node.js package with:
 ```typescript
 import { APortClient, PolicyContext } from '@aport/sdk-agent-id';
 
-const client = new APortClient('https://api.aport.dev');
+const client = new APortClient('https://api.aport.io');
 const passport = await client.getPassport();
 const result = await client.verifyPolicy({
   repo: 'owner/repo',
@@ -163,7 +163,7 @@ import (
 )
 
 func main() {
-    client := aport.NewClient("https://api.aport.dev")
+    client := aport.NewClient("https://api.aport.io")
     passport, err := client.GetPassport()
     if err != nil {
         panic(err)
@@ -332,7 +332,7 @@ MIT License - see LICENSE file for details.
 
 ## 🆘 Support
 
-- 📖 [Documentation](https://docs.aport.dev)
+- 📖 [Documentation](https://aport.io/docs)
 - 💬 [Discord Community](https://discord.gg/aport)
 - 🐛 [Issue Tracker](https://github.com/aporthq/sdk-generator-action/issues)
-- 📧 [Email Support](mailto:support@aport.dev)
+- 📧 [Email Support](mailto:support@aport.io)
diff --git a/integrations/github/actions/sdk-generator/action.yml b/integrations/github/actions/sdk-generator/action.yml
index 0f5a13b..d4aeb6c 100644
--- a/integrations/github/actions/sdk-generator/action.yml
+++ b/integrations/github/actions/sdk-generator/action.yml
@@ -12,7 +12,7 @@ inputs:
   api-base:
     description: "The base URL for the APort API."
     required: false
-    default: "https://api.aport.dev"
+    default: "https://api.aport.io"
   output-dir:
     description: "Directory to output generated SDK files."
     required: false
diff --git a/integrations/github/actions/sdk-generator/example-repo/README.md b/integrations/github/actions/sdk-generator/example-repo/README.md
index 91b66fe..6a57905 100644
--- a/integrations/github/actions/sdk-generator/example-repo/README.md
+++ b/integrations/github/actions/sdk-generator/example-repo/README.md
@@ -10,7 +10,7 @@ Click the "Fork" button to create your own copy of this repository.
 
 ### 2. Set up APort Agent
 
-1. Go to [APort Dashboard](https://aport.dev)
+1. Go to [APort Dashboard](https://aport.io)
 2. Create a new agent
 3. Configure the agent with capabilities and policies
 4. Note the Agent ID
@@ -293,13 +293,13 @@ MIT License - see LICENSE file for details.
 
 ## 🆘 Support
 
-- 📖 [APort Documentation](https://docs.aport.dev)
+- 📖 [APort Documentation](https://aport.io/docs)
 - 💬 [Discord Community](https://discord.gg/aport)
 - 🐛 [Issue Tracker](https://github.com/aporthq/sdk-generator-action/issues)
-- 📧 [Email Support](mailto:support@aport.dev)
+- 📧 [Email Support](mailto:support@aport.io)
 
 ## 🔗 Related
 
-- [APort Dashboard](https://aport.dev)
+- [APort Dashboard](https://aport.io)
 - [SDK Generator Action](https://github.com/aporthq/sdk-generator-action)
-- [APort Documentation](https://docs.aport.dev)
+- [APort Documentation](https://aport.io/docs)
diff --git a/integrations/github/actions/sdk-generator/simple-example.yml b/integrations/github/actions/sdk-generator/simple-example.yml
new file mode 100644
index 0000000..263bcc5
--- /dev/null
+++ b/integrations/github/actions/sdk-generator/simple-example.yml
@@ -0,0 +1,16 @@
+# Simple APort SDK Generation
+# Copy this to your .github/workflows/ directory
+
+name: Generate APort SDK
+on: [workflow_dispatch]
+
+jobs:
+  generate-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aporthq/sdk-generator-action@v1
+        with:
+          agent-id: ${{ secrets.APORT_AGENT_ID }}
+          languages: "python,nodejs"
+          output-dir: "./generated-sdk"
```
