### PR TITLE
⚙️ Deploy SDK Generator Action - Add new policies

### DIFF
--- a/DEPLOYMENT_INFO
+++ b/DEPLOYMENT_INFO
@@ -1,4 +1,4 @@
-Deployed from: aporthq/agent-passport@90dcea124e3bb050fe026e8861c134644a2f5675
-Deployed at: Mon Sep 22 19:41:12 UTC 2025
+Deployed from: aporthq/agent-passport@e361b1e51b40816ea2e195ca8154d21b62863ae3
+Deployed at: Wed Oct  8 05:23:23 UTC 2025
 Triggered by: uchibeke
 Action: sdk-generator

--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,7 @@ class APortClient:
     def verify_policy(self, context: PolicyContext) -> Dict[str, Any]:
         """Verify policy against agent"""
         response = requests.post(
-            f"{self.api_base}/api/verify/policy/repo.v1",
+            f"{self.api_base}/api/verify/policy/code.repository.merge.v1",
             json={"agent_id": self.agent_id, "context": context.dict()}
         )
         response.raise_for_status()
@@ -246,7 +246,7 @@ export class APortClient {
   }
 
   async verifyPolicy(context: PolicyContext): Promise<any> {
-    const response = await fetch(\`\${this.apiBase}/api/verify/policy/repo.v1\`, {
+    const response = await fetch(\`\${this.apiBase}/api/verify/policy/code.repository.merge.v1\`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -382,7 +382,7 @@ func (c *APortClient) GetPassport() (*AgentPassport, error) {
 
 // VerifyPolicy verifies policy against the agent
 func (c *APortClient) VerifyPolicy(ctx PolicyContext) (map[string]interface{}, error) {
-    url := fmt.Sprintf("%s/api/verify/policy/repo.v1", c.apiBase)
+    url := fmt.Sprintf("%s/api/verify/policy/code.repository.merge.v1", c.apiBase)
     
     payload := map[string]interface{}{
         "agent_id": c.agentID,


### PR DESCRIPTION
## ⚙️ SDK Generator Action Changes

**Source Commit:** `e361b1e51b40816ea2e195ca8154d21b62863ae3`
**Commit Message:** `Add new policies`
**Changed Files:**

- `integrations/github/actions/sdk-generator/action.yml`

### File Changes:

```diff
diff --git a/integrations/github/actions/sdk-generator/action.yml b/integrations/github/actions/sdk-generator/action.yml
index d4aeb6c..eaef8c3 100644
--- a/integrations/github/actions/sdk-generator/action.yml
+++ b/integrations/github/actions/sdk-generator/action.yml
@@ -128,7 +128,7 @@ class APortClient:
     def verify_policy(self, context: PolicyContext) -> Dict[str, Any]:
         """Verify policy against agent"""
         response = requests.post(
-            f"{self.api_base}/api/verify/policy/repo.v1",
+            f"{self.api_base}/api/verify/policy/code.repository.merge.v1",
             json={"agent_id": self.agent_id, "context": context.dict()}
         )
         response.raise_for_status()
@@ -246,7 +246,7 @@ export class APortClient {
   }
 
   async verifyPolicy(context: PolicyContext): Promise<any> {
-    const response = await fetch(\`\${this.apiBase}/api/verify/policy/repo.v1\`, {
+    const response = await fetch(\`\${this.apiBase}/api/verify/policy/code.repository.merge.v1\`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -382,7 +382,7 @@ func (c *APortClient) GetPassport() (*AgentPassport, error) {
 
 // VerifyPolicy verifies policy against the agent
 func (c *APortClient) VerifyPolicy(ctx PolicyContext) (map[string]interface{}, error) {
-    url := fmt.Sprintf("%s/api/verify/policy/repo.v1", c.apiBase)
+    url := fmt.Sprintf("%s/api/verify/policy/code.repository.merge.v1", c.apiBase)
     
     payload := map[string]interface{}{
         "agent_id": c.agentID,
```
